### PR TITLE
Change format for use flag Redis keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,14 @@
 CHANGELOG
 =========
 
+Unreleased
+==========
+
+- The format for Redis keys for user flags was changed from
+  ``FLAG:user:<uid>:<FLAG_NAME_UPPER>`` to ``FLAG:<FLAG_NAME_UPPER>:user:<uid>``.
+
 0.1.0 - 2020-01-22
 ==================
 
 - Initial release. There are "Flags", "Samples", and "Switches" to control your
-  application. 
+  application.

--- a/flask_pancake/flags.py
+++ b/flask_pancake/flags.py
@@ -100,7 +100,7 @@ class Flag(BaseFlag):
         uid = get_user_id_func()
         if uid is None:
             return None
-        return f"{self.__class__.__name__.upper()}:user:{uid}:{self.name.upper()}"
+        return f"{self.key}:user:{uid}"
 
     def is_active(self) -> bool:
         user_key = self.user_key

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -50,7 +50,7 @@ def test_flag_user(app: Flask):
     assert feature.is_active() is True
 
     assert app.extensions["redis"].get("FLAG:FEATURE") == RAW_FALSE
-    assert app.extensions["redis"].get(f"FLAG:user:{uid1}:FEATURE") == RAW_TRUE
+    assert app.extensions["redis"].get(f"FLAG:FEATURE:user:{uid1}") == RAW_TRUE
 
     app.extensions[EXTENSION_NAME].get_user_id_func = lambda: uid2
     assert feature.is_active() is False
@@ -63,7 +63,7 @@ def test_flag_user(app: Flask):
     feature.disable_user()
 
     assert feature.is_active() is False
-    assert app.extensions["redis"].get(f"FLAG:user:{uid2}:FEATURE") == RAW_FALSE
+    assert app.extensions["redis"].get(f"FLAG:FEATURE:user:{uid2}") == RAW_FALSE
 
     feature.clear()
     assert app.extensions["redis"].get("SAMPLE:FEATURE") is None


### PR DESCRIPTION
By moving the `:user:<uid>` to the end of the key, there's a better way
to scope keys in the future, e.g. multiple FlaskPancake extensions
running simultaneously.