### PR TITLE
Add a pancake command group to the Flask CLI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,24 @@ CHANGELOG
 Unreleased
 ==========
 
+- Added Flask CLI commands to manage flags, samples, and switches. Check out
+  ``flask pancake --help``:
+
+  .. code-block:: console
+
+     $ flask pancake --help
+     Usage: flask pancake [OPTIONS] COMMAND [ARGS]...
+
+       Commands to manage flask-pancake flags, samples, and switches.
+
+     Options:
+       --help  Show this message and exit.
+
+     Commands:
+       flags
+       samples
+       switches
+
 0.3.0 - 2020-04-26
 ==================
 

--- a/flask_pancake/commands.py
+++ b/flask_pancake/commands.py
@@ -1,0 +1,158 @@
+import click
+from flask import current_app
+from flask.cli import AppGroup
+
+from .extension import EXTENSION_NAME
+
+pancake_cli = AppGroup(
+    "pancake", help="Commands to manage flask-pancake flags, samples, and switches."
+)
+
+
+# FLAGS
+
+
+flags_cli = AppGroup("flags")
+pancake_cli.add_command(flags_cli)
+
+
+@flags_cli.command("clear")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def flag_clear(extension, name):
+    current_app.extensions[extension].flags[name].clear()
+    click.echo(f"Flag '{name}' cleared.")
+
+
+@flags_cli.command("clear-group")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+@click.argument("group")
+@click.argument("id")
+def flag_clear_group(extension, name, group, id):
+    current_app.extensions[extension].flags[name].clear_group(
+        group_id=group, object_id=id
+    )
+    click.echo(f"Object {id!r} in group '{group}' for flag '{name}' cleared.")
+
+
+@flags_cli.command("disable")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def flag_disable(extension, name):
+    current_app.extensions[extension].flags[name].disable()
+    click.echo(f"Flag '{name}' disabled.")
+
+
+@flags_cli.command("disable-group")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+@click.argument("group")
+@click.argument("id")
+def flag_disable_group(extension, name, group, id):
+    current_app.extensions[extension].flags[name].disable_group(
+        group_id=group, object_id=id
+    )
+    click.echo(f"Object {id!r} in group '{group}' for flag '{name}' disabled.")
+
+
+@flags_cli.command("enable")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def flag_enable(extension, name):
+    current_app.extensions[extension].flags[name].enable()
+    click.echo(f"Flag '{name}' enabled.")
+
+
+@flags_cli.command("enable-group")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+@click.argument("group")
+@click.argument("id")
+def flag_enable_group(extension, name, group, id):
+    current_app.extensions[extension].flags[name].enable_group(
+        group_id=group, object_id=id
+    )
+    click.echo(f"Object {id!r} in group '{group}' for flag '{name}' enabled.")
+
+
+@flags_cli.command("list")
+@click.option("--extension", default=EXTENSION_NAME)
+def flag_list(extension):
+    for name, instance in sorted(current_app.extensions[extension].flags.items()):
+        click.echo(f"{name}: {instance.default}")
+
+
+# SAMPLES
+
+
+samples_cli = AppGroup("samples")
+pancake_cli.add_command(samples_cli)
+
+
+@samples_cli.command("clear")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def sample_clear(extension, name):
+    current_app.extensions[extension].samples[name].clear()
+    click.echo(f"Sample '{name}' cleared.")
+
+
+@samples_cli.command("list")
+@click.option("--extension", default=EXTENSION_NAME)
+def sample_list(extension):
+    for name, instance in sorted(current_app.extensions[extension].samples.items()):
+        click.echo(f"{name}: {instance.default}")
+
+
+def validate_set(ctx, param, value):
+    if not (0 <= value <= 100):
+        raise click.BadParameter("Value for sample must be in the range [0, 100].")
+    return value
+
+
+@samples_cli.command("set")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+@click.argument("value", type=float, callback=validate_set)
+def sample_set(extension, name, value):
+    current_app.extensions[extension].samples[name].set(value)
+    click.echo(f"Sample '{name}' set to '{value}'.")
+
+
+# SWITCHES
+
+
+switches_cli = AppGroup("switches")
+pancake_cli.add_command(switches_cli)
+
+
+@switches_cli.command("clear")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def switch_clear(extension, name):
+    current_app.extensions[extension].switches[name].clear()
+    click.echo(f"Switch '{name}' cleared.")
+
+
+@switches_cli.command("disable")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def switch_disable(extension, name):
+    current_app.extensions[extension].switches[name].disable()
+    click.echo(f"Switch '{name}' disabled.")
+
+
+@switches_cli.command("enable")
+@click.option("--extension", default=EXTENSION_NAME)
+@click.argument("name")
+def switch_enable(extension, name):
+    current_app.extensions[extension].switches[name].enable()
+    click.echo(f"Switch '{name}' enabled.")
+
+
+@switches_cli.command("list")
+@click.option("--extension", default=EXTENSION_NAME)
+def switch_list(extension):
+    for name, instance in sorted(current_app.extensions[extension].switches.items()):
+        click.echo(f"{name}: {instance.default}")

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setuptools.setup(
         "Topic :: Software Development :: Testing",
     ],
     python_requires=">=3.7",
+    entry_points={"flask.commands": ["pancake=flask_pancake.commands:pancake_cli"]},
 )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,143 @@
+import uuid
+from unittest import mock
+
+from flask_pancake import Flag, Sample, Switch
+from flask_pancake.commands import (
+    flag_clear,
+    flag_clear_group,
+    flag_disable,
+    flag_disable_group,
+    flag_enable,
+    flag_enable_group,
+    flag_list,
+    sample_clear,
+    sample_list,
+    sample_set,
+    switch_clear,
+    switch_disable,
+    switch_enable,
+    switch_list,
+)
+from flask_pancake.constants import EXTENSION_NAME
+
+
+def test_flags(app):
+    runner = app.test_cli_runner()
+    feature = Flag("FEATURE", default=False)
+
+    result = runner.invoke(flag_enable, ["FEATURE"])
+    assert feature.is_active() is True
+    assert "Flag 'FEATURE' enabled." in result.output
+
+    result = runner.invoke(flag_disable, args=["FEATURE"])
+    assert feature.is_active() is False
+    assert "Flag 'FEATURE' disabled." in result.output
+
+    feature.enable()
+    assert feature.is_active() is True
+
+    result = runner.invoke(flag_clear, args=["FEATURE"])
+    assert feature.is_active() is False
+    assert "Flag 'FEATURE' cleared." in result.output
+
+
+def test_flags_group(app):
+    runner = app.test_cli_runner()
+    feature = Flag("FEATURE", default=False)
+    uid = str(uuid.uuid4())
+    app.extensions[EXTENSION_NAME]._group_funcs = {"user": lambda: uid}
+
+    result = runner.invoke(flag_enable_group, ["FEATURE", "user", uid])
+    assert feature.is_active() is True
+    assert (
+        f"Object '{uid}' in group 'user' for flag 'FEATURE' enabled." in result.output
+    )
+
+    result = runner.invoke(flag_disable_group, args=["FEATURE", "user", uid])
+    assert feature.is_active() is False
+    assert (
+        f"Object '{uid}' in group 'user' for flag 'FEATURE' disabled." in result.output
+    )
+
+    feature.enable_group("user", object_id=uid)
+    assert feature.is_active() is True
+
+    result = runner.invoke(flag_clear_group, args=["FEATURE", "user", uid])
+    assert feature.is_active() is False
+    assert (
+        f"Object '{uid}' in group 'user' for flag 'FEATURE' cleared." in result.output
+    )
+
+
+def test_flag_list(app):
+    runner = app.test_cli_runner()
+    Flag("FEATURE1", default=False)
+    Flag("FEATURE3", default=True)
+    Flag("FEATURE2", default=False)
+
+    result = runner.invoke(flag_list)
+    assert result.output == "FEATURE1: False\nFEATURE2: False\nFEATURE3: True\n"
+
+
+def test_sample(app):
+    runner = app.test_cli_runner()
+    sample = Sample("SAMPLE", default=0)
+
+    with mock.patch("random.uniform", return_value=41.999):
+        assert sample.is_active() is False
+
+    result = runner.invoke(sample_set, ["SAMPLE", "42"])
+    assert "Sample 'SAMPLE' set to '42.0'." in result.output
+    with mock.patch("random.uniform", return_value=41):
+        assert sample.is_active()
+
+    result = runner.invoke(sample_clear, args=["SAMPLE"])
+    with mock.patch("random.uniform", return_value=41.999):
+        assert sample.is_active() is False
+    assert "Sample 'SAMPLE' cleared." in result.output
+
+    result = runner.invoke(sample_set, ["SAMPLE", "101"])
+    assert (
+        "Invalid value for 'VALUE': Value for sample must be in the range [0, 100]."
+        in result.output
+    )
+
+
+def test_sample_list(app):
+    runner = app.test_cli_runner()
+    Sample("SAMPLE1", default=1)
+    Sample("SAMPLE3", default=2)
+    Sample("SAMPLE2", default=3)
+
+    result = runner.invoke(sample_list)
+    assert result.output == "SAMPLE1: 1\nSAMPLE2: 3\nSAMPLE3: 2\n"
+
+
+def test_switch(app):
+    runner = app.test_cli_runner()
+    switch = Switch("SWITCH", default=False)
+
+    result = runner.invoke(switch_enable, ["SWITCH"])
+    assert switch.is_active() is True
+    assert "Switch 'SWITCH' enabled." in result.output
+
+    result = runner.invoke(switch_disable, args=["SWITCH"])
+    assert switch.is_active() is False
+    assert "Switch 'SWITCH' disabled." in result.output
+
+    switch.enable()
+    assert switch.is_active() is True
+
+    result = runner.invoke(switch_clear, args=["SWITCH"])
+    assert switch.is_active() is False
+    assert "Switch 'SWITCH' cleared." in result.output
+
+
+def test_switch_list(app):
+    runner = app.test_cli_runner()
+    Switch("SWITCH1", default=False)
+    Switch("SWITCH3", default=True)
+    Switch("SWITCH2", default=False)
+
+    result = runner.invoke(switch_list)
+    assert result.output == "SWITCH1: False\nSWITCH2: False\nSWITCH3: True\n"


### PR DESCRIPTION
The commands expose clearing, disabling, enabling, and listing of flags,
samples, and switches. For example:
```
$ flask pancake samples set MY_SAMPLE 42
Sample 'MY_SAMPLE' set to '42'.
$ flask pancake flags list
FLAG_1: True
FLAG_2: False
```
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
