### PR TITLE
Add function to list tracked object_ids

### DIFF
--- a/flask_pancake/flags.py
+++ b/flask_pancake/flags.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import random
-from typing import TYPE_CHECKING, Dict, Generic, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Optional, Tuple, TypeVar, List
 
 from cached_property import cached_property
 from flask import current_app, g
@@ -154,6 +154,14 @@ class Flag(BaseFlag):
             return False
 
         return None
+
+    def get_tracked_object_ids(self, group_id: str) -> List[str]:
+        object_ids = []
+        _, tracking_key = self._get_group_keys(group_id)
+        object_keys = self._redis_client.smembers(tracking_key)
+        for object_key in object_keys:
+            object_ids.append(object_key.decode("utf-8").rpartition(":")[2])
+        return object_ids
 
     def _track_object(self, group_id: str, object_key: str):
         self._redis_client.sadd(self._get_group_keys(group_id)[1], object_key)

--- a/flask_pancake/flags.py
+++ b/flask_pancake/flags.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import random
-from typing import TYPE_CHECKING, Dict, Generic, Optional, Tuple, TypeVar, List
+from typing import TYPE_CHECKING, Dict, Generic, List, Optional, Tuple, TypeVar
 
 from cached_property import cached_property
 from flask import current_app, g

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -352,3 +352,19 @@ def test_get_group_keys_group_not_defined(app: Flask):
     )
     with pytest.raises(RuntimeError, match=msg):
         feature._get_group_keys("user")
+
+
+def test_get_tracked_object_ids(app: Flask):
+    uid1 = str(uuid.uuid4())
+    uid2 = str(uuid.uuid4())
+    app.extensions[EXTENSION_NAME]._group_funcs = {"user": lambda: noop}
+    feature = Flag("FEATURE", False)
+    feature.enable_group("user", object_id=uid1)
+    feature.disable_group("user", object_id=uid2)
+
+    tracked_object_ids = feature.get_tracked_object_ids("user")
+    assert set(tracked_object_ids) == set([uid1, uid2])
+
+    feature.clear_group("user", object_id=uid1)
+    tracked_object_ids = feature.get_tracked_object_ids("user")
+    assert set(tracked_object_ids) == set([uid2])


### PR DESCRIPTION
I needed to be able to list the tracked object ids in an admin view so figured it might be worth adding the function for everyone to use.

Should I add some documentation on this method in the README?